### PR TITLE
Update Python version to allow all version 3.13.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: Microsoft :: Windows",
     ],
-    python_requires='>= 3.6, <= 3.13',
+    python_requires='>= 3.6, < 3.14',
     include_package_data=True,
 )


### PR DESCRIPTION
Update Python version to allow all version 3.13.*

Thanks for this package! It helps to have some possibility to interact with .adicht files from Windows.

I ran into an issue when installing in Python 3.13.7. The current specification of <=3.13 fails install for Python versions > 3.13.0. Setting the requirement to < 3.14 fixes this, if this is indeed supported as implied by:

"Currently requires Python 3.6-3.11 with some of the newer versions requiring 64 bit Python (this can change but requires some work on my end)"

And the current requirement:
Requires: Python <=3.13, >=3.6

